### PR TITLE
Remove EOL'ed Wheezy7 from Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - bundle exec kitchen test
 env:
   matrix:
-    - DISTRIB=debian:wheezy/7
     - DISTRIB=debian:jessie/8
     - DISTRIB=debian:stretch/9
     - DISTRIB=ubuntu:xenial/16.04


### PR DESCRIPTION
Debian Wheezy was announced end-of-life May 31, 2018.  It should not be tested against as the required repos have been removed.